### PR TITLE
Update base api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.23.0</version>
+  <version>3.28.0</version>
   <scope>provided</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>money-transfer-retailer-interface</artifactId>
-    <version>2.19.0</version>
+    <version>2.21.0</version>
 </dependency>
 <dependency>
   <groupId>io.electrum</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>money-transfer-retailer-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-RC1</version>
+  <version>${major-version}.${minor-version}.${patch-version}</version>
   <packaging>jar</packaging>
   <name>money-transfer-retailer-interface</name>
   <description>Money Transfer Retailer Interface</description>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.22.0</service-interface-base-version>
+    <service-interface-base-version>3.25.0</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.9</swagger-version>
     <jetty-version>9.3.24.v20180605</jetty-version>
@@ -45,7 +45,7 @@
     <slf4j-version>1.7.5</slf4j-version>
     <logback-version>1.0.13</logback-version>
     <major-version>2</major-version>
-    <minor-version>19</minor-version>
+    <minor-version>20</minor-version>
     <patch-version>0</patch-version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>money-transfer-retailer-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}</version>
+  <version>${major-version}.${minor-version}.${patch-version}-RC1</version>
   <packaging>jar</packaging>
   <name>money-transfer-retailer-interface</name>
   <description>Money Transfer Retailer Interface</description>
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.25.0</service-interface-base-version>
+    <service-interface-base-version>3.28.0</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.9</swagger-version>
     <jetty-version>9.3.24.v20180605</jetty-version>
@@ -45,7 +45,7 @@
     <slf4j-version>1.7.5</slf4j-version>
     <logback-version>1.0.13</logback-version>
     <major-version>2</major-version>
-    <minor-version>20</minor-version>
+    <minor-version>21</minor-version>
     <patch-version>0</patch-version>
   </properties>
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,17 @@
 This page describes changes to the Money Transfer Retailer Interface implemented across different releases of the interface.
 
+## v2.20.0
+
+Released 18 June 2020
+
+- Updated the service-interface-base plugin version from v3.23.0 to v3.25.0. This version update includes the following from service-interface-base:
+     - v3.25.0
+          - Added a new field `amounts` to the `BasicAdvice` model.
+     - v3.24.0
+          - Added support for hashed PINs (via a new sub-type of `Pin` named `HashedPin`).
+     - v3.23.0
+          - Added utility methods to JsonUtil class to assist in reading the contents of a file as a string and deserialising JSON objects from files.
+
 ## v2.19.0
 
 Released 03 March 2020

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -11,7 +11,7 @@ Released 25 August 2020
         -  Added `RewardPayment` method.
         -  Provided testing utilities to aid API development in the Java implementation provided by Electrum.
     -  v3.26.0
-        -  Added Account PaymentMethod.
+        -  Added `Account` `PaymentMethod`.
         -  Added Interfaces for HasAmounts & HasPaymentMethods. These can be used for creating shared utilities across API implementations.
 
 ## v2.20.0

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -12,7 +12,7 @@ Released 25 August 2020
         -  Provided testing utilities to aid API development in the Java implementation provided by Electrum.
     -  v3.26.0
         -  Added `Account` `PaymentMethod`.
-        -  Added Interfaces for HasAmounts & HasPaymentMethods. These can be used for creating shared utilities across API implementations.
+        -  Added interfaces for `HasAmounts` & `HasPaymentMethods` to the Java implementation provided by Electrum. These can be used for creating shared utilities across API implementations.
 
 ## v2.20.0
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,6 +1,20 @@
 This page describes changes to the Money Transfer Retailer Interface implemented across different releases of the interface.
 
-## v2.20.0
+## v2.21.0
+
+Released 18 August 2020
+
+- Updated the `service-interface-base` plugin version from v3.25.0 to v3.28.0. This version update includes the following from `service-interface-base`:
+    - v3.28.0
+         - Added `operatorId` field to the `Originator` model.
+    - v3.27.0
+        -  Added `RewardPayment` method.
+        -  Provided testing utilities to aid API development in the Java implementation provided by Electrum.
+    -  v3.26.0
+        -  Added Account PaymentMethod.
+        -  Added Interfaces for HasAmounts & HasPaymentMethods. These can be used for creating shared utilities across API implementations.
+
+## vv2.20.0
 
 Released 18 June 2020
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -4,7 +4,7 @@ This page describes changes to the Money Transfer Retailer Interface implemented
 
 Released 25 August 2020
 
-- Updated the `service-interface-base` plugin version from v3.25.0 to v3.28.0. This version update includes the following from `service-interface-base`:
+- Updated the `service-interface-base` library version from v3.25.0 to v3.28.0. This version update includes the following from `service-interface-base`:
     - v3.28.0
          - Added `operatorId` field to the `Originator` model.
     - v3.27.0

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -2,7 +2,7 @@ This page describes changes to the Money Transfer Retailer Interface implemented
 
 ## v2.21.0
 
-Released 18 August 2020
+Released 25 August 2020
 
 - Updated the `service-interface-base` plugin version from v3.25.0 to v3.28.0. This version update includes the following from `service-interface-base`:
     - v3.28.0

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -14,7 +14,7 @@ Released 18 August 2020
         -  Added Account PaymentMethod.
         -  Added Interfaces for HasAmounts & HasPaymentMethods. These can be used for creating shared utilities across API implementations.
 
-## vv2.20.0
+## v2.20.0
 
 Released 18 June 2020
 

--- a/src/main/java/io/electrum/moneytransfer/model/MoneyTransferAuthRequest.java
+++ b/src/main/java/io/electrum/moneytransfer/model/MoneyTransferAuthRequest.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.EncryptedPin;
 import io.electrum.vas.model.LedgerAmount;
@@ -20,7 +21,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Used to submit data in a call to the createOrder operation.
  */
 @ApiModel(description = "Used to submit data in a call to the createOrder operation.")
-public class MoneyTransferAuthRequest extends Transaction {
+public class MoneyTransferAuthRequest extends Transaction implements HasAmounts {
 
    private LedgerAmount amount = null;
 

--- a/src/main/java/io/electrum/moneytransfer/model/MoneyTransferAuthResponse.java
+++ b/src/main/java/io/electrum/moneytransfer/model/MoneyTransferAuthResponse.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
@@ -18,7 +19,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Contains the data returned by a call to the createOrder operation.
  */
 @ApiModel(description = "Contains the data returned by a call to the createOrder operation.")
-public class MoneyTransferAuthResponse extends Transaction {
+public class MoneyTransferAuthResponse extends Transaction implements HasAmounts {
 
    private LedgerAmount amount = null;
 
@@ -42,7 +43,7 @@ public class MoneyTransferAuthResponse extends Transaction {
    /**
     * The amount to be transferred. This field may be deprecated in a future version of the API. We encourage you to
     * please also populate the 'amounts.requestAmount' field with this information.
-    * 
+    *
     * @return amount
     **/
    @JsonProperty("amount")
@@ -65,7 +66,7 @@ public class MoneyTransferAuthResponse extends Transaction {
 
    /**
     * Get senderDetails
-    * 
+    *
     * @return senderDetails
     **/
    @JsonProperty("senderDetails")
@@ -87,7 +88,7 @@ public class MoneyTransferAuthResponse extends Transaction {
 
    /**
     * Reference used by the recipient to redeem the order. This must be printed on the receipt.
-    * 
+    *
     * @return orderRedeemRef
     **/
    @JsonProperty("orderRedeemRef")
@@ -108,7 +109,7 @@ public class MoneyTransferAuthResponse extends Transaction {
 
    /**
     * An alternate reference used by the recipient to redeem the order. This must be printed on the receipt.
-    * 
+    *
     * @return orderRedeemRefAlt
     **/
    @JsonProperty("orderRedeemRefAlt")
@@ -133,7 +134,7 @@ public class MoneyTransferAuthResponse extends Transaction {
     * Note that any reference issued by the provider that is specific to a particular leg of the order process should be
     * set as a ThirdPartyIdentifier (i.e. the authorization and redeem legs of the order should each have its own
     * reference).
-    * 
+    *
     * @return orderId
     **/
    @JsonProperty("orderId")

--- a/src/main/java/io/electrum/moneytransfer/model/MoneyTransferRedeemRequest.java
+++ b/src/main/java/io/electrum/moneytransfer/model/MoneyTransferRedeemRequest.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import io.electrum.vas.interfaces.HasAmounts;
 import org.hibernate.validator.constraints.Length;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,7 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Used to submit data in a call to the redeemOrder operation.
  */
 @ApiModel(description = "Used to submit data in a call to the redeemOrder operation.")
-public class MoneyTransferRedeemRequest extends Transaction {
+public class MoneyTransferRedeemRequest extends Transaction implements HasAmounts {
 
    private LedgerAmount amount = null;
 

--- a/src/main/java/io/electrum/moneytransfer/model/MoneyTransferRedeemResponse.java
+++ b/src/main/java/io/electrum/moneytransfer/model/MoneyTransferRedeemResponse.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
@@ -18,7 +19,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Contains the data returned by a call to the redeemOrder operation.
  */
 @ApiModel(description = "Contains the data returned by a call to the redeemOrder operation.")
-public class MoneyTransferRedeemResponse extends Transaction {
+public class MoneyTransferRedeemResponse extends Transaction implements HasAmounts {
 
    private LedgerAmount amount = null;
 
@@ -31,7 +32,7 @@ public class MoneyTransferRedeemResponse extends Transaction {
    /**
     * The amount to be transferred. This field may be deprecated in a future version of the API. We encourage you to
     * please also populate the 'amounts.requestAmount' field with this information.
-    * 
+    *
     * @return amount
     **/
    @JsonProperty("amount")
@@ -58,7 +59,7 @@ public class MoneyTransferRedeemResponse extends Transaction {
     * Note that any reference issued by the provider that is specific to a particular leg of the order process should be
     * set as a ThirdPartyIdentifier (i.e. the authorization and redeem legs of the order should each have its own
     * reference).
-    * 
+    *
     * @return orderId
     **/
    @JsonProperty("orderId")


### PR DESCRIPTION
## v2.21.0

Released 25 August 2020

- Updated the `service-interface-base` plugin version from v3.25.0 to v3.28.0. This version update includes the following from `service-interface-base`:
    - v3.28.0
         - Added `operatorId` field to the `Originator` model.
    - v3.27.0
        -  Added `RewardPayment` method.
        -  Provided testing utilities to aid API development in the Java implementation provided by Electrum.
    -  v3.26.0
        -  Added Account PaymentMethod.
        -  Added Interfaces for HasAmounts & HasPaymentMethods. These can be used for creating shared utilities across API implementations.
